### PR TITLE
Implement boss fight transition and score carryover

### DIFF
--- a/src/gdd/Game.java
+++ b/src/gdd/Game.java
@@ -14,7 +14,6 @@ public class Game extends JFrame  {
     public Game() {
         titleScene = new TitleScene(this);
         scene1 = new Scene1(this);
-        bossFight = new BossFight(this);
         initUI();
         loadTitle();
         //loadScene2();
@@ -40,7 +39,8 @@ public class Game extends JFrame  {
         repaint();
     }
 
-    public void loadScene1() {
+    public void bossfight() {
+        bossFight = new BossFight(this, scene1.score);
         getContentPane().removeAll();
         add(bossFight);
         titleScene.stop();
@@ -49,7 +49,7 @@ public class Game extends JFrame  {
         repaint();
     }
 
-    public void loadScene2() {
+    public void loadscene1() {
         getContentPane().removeAll();
         add(scene1);
         titleScene.stop();

--- a/src/gdd/scene/BossFight.java
+++ b/src/gdd/scene/BossFight.java
@@ -43,6 +43,10 @@ public class BossFight extends JPanel {
     private Player player;
     // private Shot shot;
 
+
+    public int score;
+    private int playerSpeed = 5; // Player speed is reset to 5 for boss level
+
     final int BLOCKHEIGHT = 50;
     final int BLOCKWIDTH = 50;
 
@@ -95,8 +99,9 @@ public class BossFight extends JPanel {
     private int lastRowToShow;
     private int firstRowToShow;
 
-    public BossFight(Game game) {
+    public BossFight(Game game, int score) {
         this.game = game;
+        this.score = score; // get the score from Scene1, ref in Game.java
         // initBoard();
         // gameInit();
         loadSpawnDetails();
@@ -363,7 +368,15 @@ public class BossFight extends JPanel {
             gameOver(g);
         }
 
+        
+        g.setColor(Color.white);
+        g.setFont(new Font("Arial", Font.BOLD, 14));
+        g.drawString("Score: " + score, 10, 50);
+        g.drawString("Speed: " + playerSpeed, 10, 70);
+
         Toolkit.getDefaultToolkit().sync();
+
+        
     }
 
     private void gameOver(Graphics g) {
@@ -413,11 +426,13 @@ public class BossFight extends JPanel {
                     break;
             }
         }
+        
+        final int NUMBER_OF_ALIENS_TO_DESTROY = 10; // Adjust this number as needed
 
         if (deaths == NUMBER_OF_ALIENS_TO_DESTROY) {
             inGame = false;
             timer.stop();
-            message = "Game won!";
+            message = "Boss defeated! Game won!";
         }
 
         // player
@@ -429,6 +444,7 @@ public class BossFight extends JPanel {
                 powerup.act();
                 if (powerup.collidesWith(player)) {
                     powerup.upgrade(player);
+                    playerSpeed = player.getSpeed(); // Update speed if powerup affects speed
                 }
             }
         }
@@ -463,6 +479,8 @@ public class BossFight extends JPanel {
                         enemy.setImage(ii.getImage());
                         enemy.setDying(true);
                         explosions.add(new Explosion(enemyX, enemyY));
+                        score += 10;  // Add score when enemy is hit
+                        System.out.println("Score: " + score);
                         deaths++;
                         shot.die();
                         shotsToRemove.add(shot);
@@ -574,7 +592,7 @@ public class BossFight extends JPanel {
 
         @Override
         public void keyPressed(KeyEvent e) {
-            System.out.println("Scene2.keyPressed: " + e.getKeyCode());
+            System.out.println("BossFight.keyPressed: " + e.getKeyCode());
 
             player.keyPressed(e);
 

--- a/src/gdd/scene/Scene1.java
+++ b/src/gdd/scene/Scene1.java
@@ -43,7 +43,7 @@ public class Scene1 extends JPanel {
     private Player player;
     // private Shot shot;
 
-    private int score = 0;
+    public int score = 0;
     private int playerSpeed = 5;
 
     final int BLOCKHEIGHT = 50;
@@ -62,6 +62,8 @@ public class Scene1 extends JPanel {
 
     private Timer timer;
     private final Game game;
+
+    private boolean bossFightStarted = false;
 
     private int currentRow = -1;
     // TODO load this map from a file
@@ -138,6 +140,15 @@ public class Scene1 extends JPanel {
         spawnMap.put(502, new SpawnDetails("Alien1", 200, 0));
         spawnMap.put(503, new SpawnDetails("Alien1", 350, 0));
 
+        
+        spawnMap.put(600, new SpawnDetails("Alien1", 200, 0));
+        spawnMap.put(601, new SpawnDetails("Alien1", 250, 0));
+        spawnMap.put(602, new SpawnDetails("Alien1", 300, 0));
+        spawnMap.put(603, new SpawnDetails("Alien1", 450, 0));
+
+        
+        spawnMap.put(700, new SpawnDetails("Alien1", 100, 0));
+        spawnMap.put(701, new SpawnDetails("Alien1", 550, 0));
         
     }
 
@@ -373,9 +384,9 @@ public class Scene1 extends JPanel {
         }
 
         g.setColor(Color.white);
-g.setFont(new Font("Arial", Font.BOLD, 14));
-g.drawString("Score: " + score, 10, 50);
-g.drawString("Speed: " + playerSpeed, 10, 70);
+        g.setFont(new Font("Arial", Font.BOLD, 14));
+        g.drawString("Score: " + score, 10, 50);
+        g.drawString("Speed: " + playerSpeed, 10, 70);
 
 
         Toolkit.getDefaultToolkit().sync();
@@ -399,6 +410,16 @@ g.drawString("Speed: " + playerSpeed, 10, 70);
         g.setFont(small);
         g.drawString(message, (BOARD_WIDTH - fontMetrics.stringWidth(message)) / 2,
                 BOARD_WIDTH / 2);
+
+
+        // Transition to boss fight
+        if (message.equals("Stage 1 Game won! Going to Boss Fight ...") && !bossFightStarted) {
+            bossFightStarted = true;
+            new Timer(3000, e -> {
+                ((Timer) e.getSource()).stop();
+                game.bossfight();
+            }).start();
+    }
     }
 
     private void update() {
@@ -429,11 +450,13 @@ g.drawString("Speed: " + playerSpeed, 10, 70);
                     break;
             }
         }
-        final int NUMBER_OF_ALIENS_TO_DESTROY = 10; // Adjust this number as needed
+        final int NUMBER_OF_ALIENS_TO_DESTROY = 16; // Adjust this number as needed
         if (deaths == NUMBER_OF_ALIENS_TO_DESTROY) {
             inGame = false;
             timer.stop();
-            message = "Game won!";
+            message = "Stage 1 Game won! Going to Boss Fight ...";
+            
+            // game.bossfight();
         }
 
         // player
@@ -594,7 +617,7 @@ g.drawString("Speed: " + playerSpeed, 10, 70);
 
         @Override
         public void keyPressed(KeyEvent e) {
-            System.out.println("Scene2.keyPressed: " + e.getKeyCode());
+            System.out.println("Scene1.keyPressed: " + e.getKeyCode());
 
             player.keyPressed(e);
 

--- a/src/gdd/scene/TitleScene.java
+++ b/src/gdd/scene/TitleScene.java
@@ -100,7 +100,7 @@ public class TitleScene extends JPanel {
         }
 
         g.setFont(g.getFont().deriveFont(22f));
-        String text = "Press SPACE to Start Scene 1 or ENTER for Boss Fight";
+        String text = "Press SPACE to Start";
         int stringWidth = g.getFontMetrics().stringWidth(text);
         int x = (d.width - stringWidth) / 2;
         // int stringHeight = g.getFontMetrics().getAscent();
@@ -149,13 +149,13 @@ public class TitleScene extends JPanel {
             System.out.println("Title.keyPressed: " + e.getKeyCode());
             int key = e.getKeyCode();
             if (key == KeyEvent.VK_SPACE) {
-                // Load the next scene
-                game.loadScene2();
+                game.loadscene1();
             }
 
-            if (key == KeyEvent.VK_ENTER){
-                game.loadScene1();
-            }
+            // Boss Fight trigger (used for testing)
+            // if (key == KeyEvent.VK_ENTER){
+            //     game.bossfight();
+            // }
 
         }
     }


### PR DESCRIPTION
- Refactored Game, Scene1, and BossFight to enable a smooth transition from Scene1 to the boss fight, carrying over the player's score.
- Scene1 now triggers the boss fight scene after a set number of enemies are defeated, and
- BossFight displays the score and player speed.
- Updated TitleScene instructions and cleaned up scene loading methods.